### PR TITLE
Fix stdlib path check helper

### DIFF
--- a/tests/test_toolwrap.py
+++ b/tests/test_toolwrap.py
@@ -100,3 +100,11 @@ def test_create_bash_wrapper(tmp_path):
     assert mode & stat.S_IXUSR
     assert mode & stat.S_IRUSR
 
+
+def test_path_is_relative_helper():
+    """Piecewise path comparison works without Path.is_relative_to."""
+    from pathlib import Path
+
+    assert toolwrap._path_is_relative_to(Path("/usr/lib/foo.py"), Path("/usr/lib"))
+    assert not toolwrap._path_is_relative_to(Path("/usr/lib64/foo.py"), Path("/usr/lib"))
+


### PR DESCRIPTION
## Summary
- add `_path_is_relative_to` helper for pre-3.9 compatibility
- use the helper in `is_standard_library`
- test helper with paths that share a prefix but are not nested

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843053539a883248428e9157277434c