### PR TITLE
Fix parse_requirements cycle handling

### DIFF
--- a/tests/test_toolwrap.py
+++ b/tests/test_toolwrap.py
@@ -65,6 +65,16 @@ git+https://example.com/repo.git#egg=bar
     assert packages == {"foo", "bar", "baz"}
 
 
+def test_parse_requirements_cycle(tmp_path):
+    """Circular -r references do not cause infinite recursion."""
+    a = tmp_path / "A.txt"
+    b = tmp_path / "B.txt"
+    a.write_text("pkg_a\n-r B.txt\n")
+    b.write_text("pkg_b\n-r A.txt\n")
+    packages = toolwrap.parse_requirements(a)
+    assert packages == {"pkg_a", "pkg_b"}
+
+
 def test_find_third_party_imports(tmp_path):
     """Standard library imports ignored; third-party detected (docs lines 192-194)."""
     script = tmp_path / "script.py"

--- a/toolwrap.py
+++ b/toolwrap.py
@@ -281,6 +281,8 @@ def parse_requirements(req_file: Path) -> Set[str]:
                     continue
                 if line.startswith("-r"):
                     nested = (path.parent / line[2:].strip()).resolve()
+                    if nested in visited:
+                        continue
                     _parse(nested)
                     continue
                 egg_match = re.search(r"#egg=([A-Za-z0-9_.-]+)", line)


### PR DESCRIPTION
## Summary
- prevent recursion into requirements that have already been visited
- test that circular references don't raise recursion errors

## Testing
- `pytest -q`