### PR TITLE
Add extra coverage for documented features

### DIFF
--- a/tests/test_toolwrap.py
+++ b/tests/test_toolwrap.py
@@ -3,6 +3,7 @@ import stat
 import subprocess
 import platform
 from pathlib import Path
+import logging
 
 import pytest
 
@@ -239,3 +240,349 @@ def test_install_dependencies_records_pip_upgrade(monkeypatch, tmp_path):
     summary = {"pip_upgraded": []}
     assert toolwrap.install_dependencies(venv, req, False, summary, "grp")
     assert summary["pip_upgraded"] == ["grp"]
+
+
+def test_is_standard_library():
+    assert toolwrap.is_standard_library("json")
+    assert not toolwrap.is_standard_library("some_nonexistent_pkg")
+
+def test_run_command(tmp_path):
+    success, out, err = toolwrap.run_command([sys.executable, "-c", "print('x')"])
+    assert success and out.strip() == "x"
+    success, _, _ = toolwrap.run_command([sys.executable, "-c", "import sys; sys.exit(1)"])
+    assert not success
+    success, out, err = toolwrap.run_command([sys.executable, "-c", "print('y')"], dry_run=True)
+    assert success and out == "" and err == ""
+
+def test_create_virtualenv_invokes_run(monkeypatch, tmp_path):
+    calls = []
+    def fake_run(cmd, cwd=None, env=None, dry_run=False):
+        calls.append(cmd)
+        return True, "", ""
+    monkeypatch.setattr(toolwrap, "run_command", fake_run)
+    assert toolwrap.create_virtualenv(Path("/py"), tmp_path / "v", False)
+    assert calls[0][:3] == ["/py", "-m", "venv"]
+
+def test_create_virtualenv_dry_run(monkeypatch, tmp_path):
+    called = False
+    def fake_run(*a, **k):
+        nonlocal called
+        called = True
+        return True, "", ""
+    monkeypatch.setattr(toolwrap, "run_command", fake_run)
+    assert toolwrap.create_virtualenv(Path("/py"), tmp_path / "v", True)
+    assert not called
+
+def test_python_version_file(monkeypatch, tmp_path):
+    src = tmp_path / "src"; bin_dir = tmp_path / "bin"; venv_root = bin_dir / ".venv"
+    grp = src / "g"; grp.mkdir(parents=True)
+    (grp / "script.py").write_text("print('a')")
+    (grp / "python_version.txt").write_text("3.9")
+    calls = []
+    def fake_find(version):
+        calls.append(version)
+        if version == "3.9":
+            return Path("/custom/python")
+        return Path(sys.executable)
+    def fake_create(py, path, dry):
+        assert py == Path("/custom/python")
+        path.mkdir(parents=True, exist_ok=True)
+        bin_p = path / "bin"; bin_p.mkdir(parents=True)
+        (bin_p / "python").write_text(""); (bin_p / "pip").write_text("")
+        return True
+    monkeypatch.setattr(toolwrap, "find_python_executable", fake_find)
+    monkeypatch.setattr(toolwrap, "create_virtualenv", fake_create)
+    monkeypatch.setattr(toolwrap, "install_dependencies", lambda *a, **k: True)
+    monkeypatch.setattr(toolwrap, "create_bash_wrapper", lambda *a, **k: True)
+    monkeypatch.setattr(sys, "argv", ["toolwrap", "--source", str(src), "--bin", str(bin_dir), "--venv-root", str(venv_root)])
+    toolwrap.main()
+    assert (venv_root / "g").is_dir()
+    assert "3.9" in calls
+
+def test_python_version_fallback(monkeypatch, tmp_path):
+    src = tmp_path / "src"; bin_dir = tmp_path / "bin"; venv_root = bin_dir / ".venv"
+    grp = src / "g"; grp.mkdir(parents=True)
+    (grp / "script.py").write_text("print('b')")
+    (grp / "python_version.txt").write_text("9.9")
+    calls = []
+    def fake_find(version):
+        calls.append(version)
+        if version == "9.9":
+            return None
+        if version == "3.8":
+            return Path("/fallback")
+        return Path(sys.executable)
+    def fake_create(py, path, dry):
+        assert py == Path("/fallback")
+        path.mkdir(parents=True, exist_ok=True)
+        bin_p = path / "bin"; bin_p.mkdir(parents=True)
+        (bin_p / "python").write_text(""); (bin_p / "pip").write_text("")
+        return True
+    monkeypatch.setattr(toolwrap, "find_python_executable", fake_find)
+    monkeypatch.setattr(toolwrap, "create_virtualenv", fake_create)
+    monkeypatch.setattr(toolwrap, "install_dependencies", lambda *a, **k: True)
+    monkeypatch.setattr(toolwrap, "create_bash_wrapper", lambda *a, **k: True)
+    monkeypatch.setattr(sys, "argv", ["toolwrap", "--source", str(src), "--bin", str(bin_dir), "--venv-root", str(venv_root), "--python-version", "3.8"])
+    toolwrap.main()
+    assert calls[0] == "3.8" and calls[1] == "9.9"
+
+def test_main_dry_run(monkeypatch, tmp_path):
+    src = tmp_path / "src"; bin_dir = tmp_path / "bin"; venv_root = bin_dir / ".venv"
+    grp = src / "g"; grp.mkdir(parents=True)
+    (grp / "script.py").write_text("print('c')")
+    created = []
+    def fake_create(py, path, dry):
+        created.append(dry)
+        return True
+    monkeypatch.setattr(toolwrap, "create_virtualenv", fake_create)
+    monkeypatch.setattr(toolwrap, "install_dependencies", lambda *a, **k: True)
+    monkeypatch.setattr(toolwrap, "create_bash_wrapper", lambda *a, **k: True)
+    monkeypatch.setattr(toolwrap, "find_python_executable", lambda v: Path(sys.executable))
+    monkeypatch.setattr(sys, "argv", ["toolwrap", "--source", str(src), "--bin", str(bin_dir), "--venv-root", str(venv_root), "--dry-run"])
+    toolwrap.main()
+    assert created == [True]
+    assert not (venv_root / "g").exists()
+    assert not (bin_dir / "script").exists()
+
+def test_missing_requirements_append(monkeypatch, tmp_path):
+    src = tmp_path / "src"; bin_dir = tmp_path / "bin"; venv_root = bin_dir / ".venv"
+    grp = src / "g"; grp.mkdir(parents=True)
+    (grp / "script.py").write_text("import numpy\n")
+    monkeypatch.setattr(toolwrap, "install_dependencies", lambda *a, **k: True)
+    monkeypatch.setattr(toolwrap, "create_bash_wrapper", lambda *a, **k: True)
+    def fake_create(py, path, dry):
+        path.mkdir(parents=True, exist_ok=True)
+        bin_p = path / "bin"; bin_p.mkdir(parents=True)
+        (bin_p / "python").write_text(""); (bin_p / "pip").write_text("")
+        return True
+    monkeypatch.setattr(toolwrap, "create_virtualenv", fake_create)
+    monkeypatch.setattr(toolwrap, "find_python_executable", lambda v: Path(sys.executable))
+    monkeypatch.setattr(sys, "argv", ["toolwrap", "--source", str(src), "--bin", str(bin_dir), "--venv-root", str(venv_root), "--missing-requirements", "append"])
+    toolwrap.main()
+    req = grp / "requirements.txt"
+    assert "numpy" in req.read_text().lower()
+
+def test_include_groups_selective(monkeypatch, tmp_path):
+    src = tmp_path / "src"; bin_dir = tmp_path / "bin"; venv_root = bin_dir / ".venv"
+    for name in ["g1", "g2"]:
+        d = src / name; d.mkdir(parents=True)
+        (d / "script.py").write_text("print('x')")
+    monkeypatch.setattr(toolwrap, "install_dependencies", lambda *a, **k: True)
+    monkeypatch.setattr(toolwrap, "create_bash_wrapper", lambda *a, **k: True)
+    def fake_create(py, path, dry):
+        path.mkdir(parents=True, exist_ok=True)
+        bin_p = path / "bin"; bin_p.mkdir(parents=True)
+        (bin_p / "python").write_text(""); (bin_p / "pip").write_text("")
+        return True
+    monkeypatch.setattr(toolwrap, "create_virtualenv", fake_create)
+    monkeypatch.setattr(toolwrap, "find_python_executable", lambda v: Path(sys.executable))
+    monkeypatch.setattr(sys, "argv", ["toolwrap", "--source", str(src), "--bin", str(bin_dir), "--venv-root", str(venv_root), "--include-groups", "g1,missing"])
+    toolwrap.main()
+    assert (venv_root / "g1").is_dir()
+    assert not (venv_root / "g2").exists()
+    assert not (venv_root / "missing").exists()
+
+
+def _fake_create_venv(path: Path):
+    """Helper to create minimal venv structure for tests."""
+    bin_dir = path / ("Scripts" if platform.system() == "Windows" else "bin")
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    (bin_dir / ("python.exe" if platform.system() == "Windows" else "python")).write_text("")
+    (bin_dir / ("pip.exe" if platform.system() == "Windows" else "pip")).write_text("")
+
+
+def test_verbose_sets_debug_logging(monkeypatch, tmp_path):
+    source = tmp_path / "src"; bin_dir = tmp_path / "bin"
+    source.mkdir(); bin_dir.mkdir()
+
+    recorded = {}
+
+    def mock_basic(level=None, **kwargs):
+        recorded['level'] = level
+
+    monkeypatch.setattr(logging, "basicConfig", mock_basic)
+    orig_iterdir = Path.iterdir
+
+    def fake_iterdir(self):
+        if self == source:
+            return iter([])
+        return orig_iterdir(self)
+
+    monkeypatch.setattr(Path, "iterdir", fake_iterdir)
+    monkeypatch.setattr(toolwrap, "check_duplicate_wrappers", lambda g: {})
+    monkeypatch.setattr(toolwrap, "find_python_executable", lambda v: Path(sys.executable))
+    monkeypatch.setattr(sys, "argv", ["toolwrap", "--source", str(source), "--bin", str(bin_dir), "--verbose"])
+
+    with pytest.raises(toolwrap.ToolwrapError):
+        toolwrap.main()
+
+    assert recorded.get('level') == logging.DEBUG
+
+
+def test_verbose_defaults_to_info(monkeypatch, tmp_path):
+    source = tmp_path / "src"; bin_dir = tmp_path / "bin"
+    source.mkdir(); bin_dir.mkdir()
+
+    recorded = {}
+
+    def mock_basic(level=None, **kwargs):
+        recorded['level'] = level
+
+    monkeypatch.setattr(logging, "basicConfig", mock_basic)
+    orig_iterdir = Path.iterdir
+
+    def fake_iterdir(self):
+        if self == source:
+            return iter([])
+        return orig_iterdir(self)
+
+    monkeypatch.setattr(Path, "iterdir", fake_iterdir)
+    monkeypatch.setattr(toolwrap, "check_duplicate_wrappers", lambda g: {})
+    monkeypatch.setattr(toolwrap, "find_python_executable", lambda v: Path(sys.executable))
+    monkeypatch.setattr(sys, "argv", ["toolwrap", "--source", str(source), "--bin", str(bin_dir)])
+
+    with pytest.raises(toolwrap.ToolwrapError):
+        toolwrap.main()
+
+    assert recorded.get('level') == logging.INFO
+
+
+def test_custom_directories(monkeypatch, tmp_path):
+    source_dir = tmp_path / "src"
+    bin_dir = tmp_path / "custom_bin"
+    venv_root = tmp_path / "custom_venv"
+    grp = source_dir / "g1"
+    for p in [source_dir, bin_dir, venv_root, grp]:
+        p.mkdir(parents=True, exist_ok=True)
+    script = grp / "tool.py"
+    script.write_text("print('hi')")
+
+    venv_paths = []
+
+    def fake_create(py, path, dry):
+        venv_paths.append(path)
+        _fake_create_venv(path)
+        return True
+
+    wrappers = []
+
+    def fake_wrapper(wp, vp, tp, dr=False):
+        wrappers.append(wp)
+        return True
+
+    monkeypatch.setattr(toolwrap, "create_virtualenv", fake_create)
+    monkeypatch.setattr(toolwrap, "create_wrapper", fake_wrapper)
+    monkeypatch.setattr(toolwrap, "install_dependencies", lambda *a, **k: True)
+    monkeypatch.setattr(toolwrap, "find_python_executable", lambda v: Path(sys.executable))
+    monkeypatch.setattr(sys, "argv", [
+        "toolwrap", "--source", str(source_dir),
+        "--bin", str(bin_dir), "--venv-root", str(venv_root)
+    ])
+
+    toolwrap.main()
+
+    assert venv_paths and venv_paths[0] == venv_root / "g1"
+    assert wrappers and wrappers[0] == bin_dir / "tool"
+
+
+def _setup_req_env(tmp_path, monkeypatch, content="existing\n"):
+    src = tmp_path / "src"; bin_dir = tmp_path / "bin"; venv_root = bin_dir / ".venv"
+    grp = src / "grp"; grp.mkdir(parents=True)
+    script = grp / "s.py"; script.write_text("import missing_pkg\n")
+    req = grp / "requirements.txt"
+    req.write_text(content)
+    def fake_create(*a, **k):
+        _fake_create_venv(a[1])
+        return True
+
+    monkeypatch.setattr(toolwrap, "create_virtualenv", fake_create)
+    monkeypatch.setattr(toolwrap, "create_wrapper", lambda *a, **k: True)
+    monkeypatch.setattr(toolwrap, "install_dependencies", lambda *a, **k: True)
+    monkeypatch.setattr(toolwrap, "find_python_executable", lambda v: Path(sys.executable))
+    monkeypatch.setattr(toolwrap, "find_third_party_imports", lambda f: {"missing_pkg"})
+    return src, bin_dir, venv_root, req
+
+
+def test_missing_requirements_suggest(monkeypatch, tmp_path, caplog):
+    caplog.set_level(logging.WARNING)
+    src, bin_dir, venv_root, req = _setup_req_env(tmp_path, monkeypatch)
+    initial = req.read_text()
+    monkeypatch.setattr(sys, "argv", [
+        "toolwrap", "--source", str(src), "--bin", str(bin_dir),
+        "--venv-root", str(venv_root), "--missing-requirements", "suggest"
+    ])
+
+    toolwrap.main()
+
+    assert req.read_text() == initial
+    assert any("[SUGGEST]" in r.message for r in caplog.records)
+
+
+def test_missing_requirements_default(monkeypatch, tmp_path, caplog):
+    caplog.set_level(logging.INFO)
+    src, bin_dir, venv_root, req = _setup_req_env(tmp_path, monkeypatch)
+    initial = req.read_text()
+    monkeypatch.setattr(sys, "argv", [
+        "toolwrap", "--source", str(src), "--bin", str(bin_dir), "--venv-root", str(venv_root)
+    ])
+
+    toolwrap.main()
+
+    assert req.read_text() == initial
+    assert not any("missing packages" in r.message for r in caplog.records)
+
+
+def test_skip_group_no_py(monkeypatch, tmp_path, caplog):
+    caplog.set_level(logging.INFO)
+    src = tmp_path / "src"; bin_dir = tmp_path / "bin"; venv_root = bin_dir / ".venv"
+    empty_grp = src / "empty"; empty_grp.mkdir(parents=True)
+
+    called = False
+
+    def fake_create(*a, **k):
+        nonlocal called
+        called = True
+        return True
+
+    monkeypatch.setattr(toolwrap, "create_virtualenv", fake_create)
+    monkeypatch.setattr(toolwrap, "create_wrapper", fake_create)
+    monkeypatch.setattr(toolwrap, "install_dependencies", fake_create)
+    monkeypatch.setattr(toolwrap, "find_python_executable", lambda v: Path(sys.executable))
+    monkeypatch.setattr(sys, "argv", ["toolwrap", "--source", str(src), "--bin", str(bin_dir), "--venv-root", str(venv_root)])
+
+    toolwrap.main()
+
+    assert not called
+    assert any("Skipping group" in r.message for r in caplog.records)
+
+
+def test_duplicate_wrappers_in_main(monkeypatch, tmp_path, caplog):
+    caplog.set_level(logging.WARNING)
+    src = tmp_path / "src"; bin_dir = tmp_path / "bin"; venv_root = bin_dir / ".venv"
+    g1 = src / "g1"; g2 = src / "g2"
+    for g in [g1, g2]:
+        g.mkdir(parents=True)
+        (g / "dup.py").write_text("print('x')")
+
+    monkeypatch.setattr(toolwrap, "install_dependencies", lambda *a, **k: True)
+
+    def fake_create(py, path, dry):
+        _fake_create_venv(path)
+        return True
+
+    monkeypatch.setattr(toolwrap, "create_virtualenv", fake_create)
+
+    created_wrappers = []
+
+    def fake_wrapper(wp, vp, tp, dr=False):
+        created_wrappers.append(wp)
+        return True
+
+    monkeypatch.setattr(toolwrap, "create_wrapper", fake_wrapper)
+    monkeypatch.setattr(toolwrap, "find_python_executable", lambda v: Path(sys.executable))
+    monkeypatch.setattr(sys, "argv", ["toolwrap", "--source", str(src), "--bin", str(bin_dir), "--venv-root", str(venv_root)])
+
+    toolwrap.main()
+
+    assert not created_wrappers
+    assert any("Duplicate wrapper names detected" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- test verbose logging level
- ensure custom `--bin` and `--venv-root` directories are honored
- verify behaviour of `--missing-requirements suggest` and default
- skip groups with no Python files
- warn and skip duplicate wrappers in `main`

## Testing
- `pytest -q`